### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <http-client.version>1.25.0</http-client.version>
         <repackagedDir>endpoints.repackaged</repackagedDir>
 
-        <gae.version>1.9.68</gae.version>
+        <gae.version>1.9.76</gae.version>
 
         <endpoints-authenticators.scm.connection>git@github.com:AODocs/endpoints-authenticators.git</endpoints-authenticators.scm.connection>
         <endpoints-authenticators.scm.url>https://github.com/AODocs/endpoints-authenticators</endpoints-authenticators.scm.url>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
         <endpoints-framework.version>2.3.3</endpoints-framework.version>
         <!--Should be compatible with version from endpoints-framework-->        
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <http-client.version>1.25.0</http-client.version>
         <repackagedDir>endpoints.repackaged</repackagedDir>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-bom</artifactId>
-                <version>0.71.0-alpha</version>
+                <version>0.111.0-alpha</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-iam</artifactId>
-            <version>v1-rev282-${http-client.version}</version>
+            <version>v1-rev289-${http-client.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>guava-jdk5</artifactId>
@@ -198,14 +198,14 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.1.3.RELEASE</version>
+            <version>5.2.0.RELEASE</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <endpoints-framework.version>2.2.1</endpoints-framework.version>
+        <endpoints-framework.version>2.3.3</endpoints-framework.version>
         <!--Should be compatible with version from endpoints-framework-->        
         <jackson.version>2.9.8</jackson.version>
         <http-client.version>1.25.0</http-client.version>
@@ -59,7 +59,7 @@
     <dependencies>
         <!--Endpoints-->
         <dependency>
-            <groupId>com.google.endpoints</groupId>
+            <groupId>com.aodocs.endpoints</groupId>
             <artifactId>endpoints-framework</artifactId>
             <version>${endpoints-framework.version}</version>
             <scope>provided</scope>
@@ -303,6 +303,19 @@
         </plugins>
     </build>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+        <repository>
+            <id>artifactory</id>
+            <name>libs-release</name>
+            <url>https://aodocs.jfrog.io/aodocs/libs-release</url>
+        </repository>
+    </repositories>
+
     <distributionManagement>
         <repository>
             <id>artifactory</id>
@@ -313,7 +326,7 @@
             <id>artifactory</id>
             <name>libs-snapshot</name>
             <url>https://aodocs.jfrog.io/aodocs/libs-snapshot</url>
-    </snapshotRepository>
+        </snapshotRepository>
     </distributionManagement>
 
 </project>


### PR DESCRIPTION
- We should use the AODocs fork of endpoints
- Some outdated dependencies had CVEs
