### PR TITLE
Support firebase  multi-cloud authentication configuration

### DIFF
--- a/src/main/java/com/aodocs/endpoints/auth/authorizers/clientid/ClientIdsAuthorizer.java
+++ b/src/main/java/com/aodocs/endpoints/auth/authorizers/clientid/ClientIdsAuthorizer.java
@@ -52,6 +52,10 @@ public final class ClientIdsAuthorizer extends AbstractAuthorizer {
 
     public AuthorizationResult isAuthorized(ExtendedUser extendedUser, ApiMethodConfig methodConfig, HttpServletRequest request) {
         String clientId = extendedUser.getAuthInfo().getClientId();
+        if (clientId == null) {
+            return newResultBuilder().authorized(false).build();
+        }
+        
         List<String> allowedClientIds = clientIdSupplier.get();
         logger.atFine().log("Class=%s, ClientId=%s, Allowed=%s", getClass(), clientId, allowedClientIds);
         return newResultBuilder().authorized(clientIdSupplier.get().contains(clientId)).build();

--- a/src/main/java/com/aodocs/endpoints/auth/authorizers/clientid/CurrentProjectClientIdAuthorizer.java
+++ b/src/main/java/com/aodocs/endpoints/auth/authorizers/clientid/CurrentProjectClientIdAuthorizer.java
@@ -32,6 +32,11 @@ import com.google.api.server.spi.config.model.ApiMethodConfig;
 public final class CurrentProjectClientIdAuthorizer extends AbstractAuthorizer {
 
     public AuthorizationResult isAuthorized(ExtendedUser extendedUser, ApiMethodConfig methodConfig, HttpServletRequest request) {
-        return newResultBuilder().authorized(ProjectConfigProvider.get().isProjectClientId(extendedUser.getAuthInfo().getClientId())).build();
+        String clientId = extendedUser.getAuthInfo().getClientId();
+        if (clientId == null) {
+            return newResultBuilder().authorized(false).build();
+        }
+    
+        return newResultBuilder().authorized(ProjectConfigProvider.get().isProjectClientId(clientId)).build();
     }
 }

--- a/src/main/java/com/aodocs/endpoints/auth/authorizers/clientid/ProjectsAuthorizer.java
+++ b/src/main/java/com/aodocs/endpoints/auth/authorizers/clientid/ProjectsAuthorizer.java
@@ -44,7 +44,12 @@ public final class ProjectsAuthorizer extends AbstractAuthorizer {
     }
 
     public AuthorizationResult isAuthorized(final ExtendedUser extendedUser, ApiMethodConfig methodConfig, HttpServletRequest request) {
-        String projectNumber = ProjectConfigProvider.extractProjectNumber(extendedUser.getAuthInfo().getClientId());
+        String clientId = extendedUser.getAuthInfo().getClientId();
+        if (clientId == null) {
+            return newResultBuilder().authorized(false).build();
+        }
+    
+        String projectNumber = ProjectConfigProvider.extractProjectNumber(clientId);
         return newResultBuilder().authorized(projectNumber != null && projectNumberSupplier.get().contains(projectNumber)).build();
     }
 


### PR DESCRIPTION
Token from firebase does not contains clientId (mapped to the
'issued_to' field of the json token) so that authorizers
reading the clientId runs into a NPE when dealing with such token.
We handle it gracefully now, whith those clientId-based
authorizers simply deny access when the clientId is not provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aodocs/endpoints-authenticators/12)
<!-- Reviewable:end -->
